### PR TITLE
[SDRAN-42] Implementing decoding of PfContainer structure

### DIFF
--- a/servicemodels/e2sm_kpm/kpmctypes/OCUCP-PF-Container.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/OCUCP-PF-Container.go
@@ -11,12 +11,13 @@ package kpmctypes
 //#include "OCUCP-PF-Container.h"
 import "C"
 import (
+	"encoding/binary"
 	e2sm_kpm_ies "github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/v1beta1/e2sm-kpm-ies"
 	"unsafe"
 )
 
-func xerEncodeOCUCPPFContainer(oCuCpContainer *e2sm_kpm_ies.OcucpPfContainer) ([]byte, error) {
-	oCuCpContainerCP, err := newOCUCPPFContainer(oCuCpContainer)
+func xerEncodeOCuCpPfContainer(oCuCpContainer *e2sm_kpm_ies.OcucpPfContainer) ([]byte, error) {
+	oCuCpContainerCP, err := newOCuCpPfContainer(oCuCpContainer)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +29,7 @@ func xerEncodeOCUCPPFContainer(oCuCpContainer *e2sm_kpm_ies.OcucpPfContainer) ([
 	return bytes, nil
 }
 
-func newOCUCPPFContainer(oCuCpC *e2sm_kpm_ies.OcucpPfContainer) (*C.OCUCP_PF_Container_t, error) {
+func newOCuCpPfContainer(oCuCpC *e2sm_kpm_ies.OcucpPfContainer) (*C.OCUCP_PF_Container_t, error) {
 	var nUEs = C.long(oCuCpC.GetCuCpResourceStatus().NumberOfActiveUes)
 
 	gnbNameCP, err := newGnbCuCpName(oCuCpC.GNbCuCpName)
@@ -48,7 +49,7 @@ func newOCUCPPFContainer(oCuCpC *e2sm_kpm_ies.OcucpPfContainer) (*C.OCUCP_PF_Con
 	return &ocucpC, nil
 }
 
-func decodeOCUCPPFContainer(oCuCpContainerC *C.OCUCP_PF_Container_t) (*e2sm_kpm_ies.OcucpPfContainer) {
+func decodeOCuCpPfContainer(oCuCpContainerC *C.OCUCP_PF_Container_t) (*e2sm_kpm_ies.OcucpPfContainer) {
 	oCuCpContainer := new(e2sm_kpm_ies.OcucpPfContainer)
 
 	oCuCpContainer.GNbCuCpName = decodeGnbCuCpName(oCuCpContainerC.gNB_CU_CP_Name)
@@ -56,4 +57,10 @@ func decodeOCUCPPFContainer(oCuCpContainerC *C.OCUCP_PF_Container_t) (*e2sm_kpm_
 	//oCuCpContainer.CuCpResourceStatus, err = decodeCuCpResouceStatus(oCuCpContainerC.cu_CP_Resource_Status)
 
 	return oCuCpContainer
+}
+
+func decodeOCuCpContainerBytes(array [8]byte) (*e2sm_kpm_ies.OcucpPfContainer) {
+	oCuCpPfContainerC := (*C.OCUCP_PF_Container_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:8]))))
+
+	return decodeOCuCpPfContainer(oCuCpPfContainerC)
 }

--- a/servicemodels/e2sm_kpm/kpmctypes/OCUCP-PF-Container_test.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/OCUCP-PF-Container_test.go
@@ -21,7 +21,7 @@ func Test_xerEncodeOCUCPPFContainer(t *testing.T) {
 			},
 		}
 
-	xer, err := xerEncodeOCUCPPFContainer(oCuCp)
+	xer, err := xerEncodeOCuCpPfContainer(oCuCp)
 	assert.NilError(t, err)
 	t.Logf("OCUCP-PF-Container XER\n%s", string(xer))
 }

--- a/servicemodels/e2sm_kpm/kpmctypes/PF-Container.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/PF-Container.go
@@ -40,7 +40,7 @@ func newPfContainer(pfContainer *e2sm_kpm_ies.PfContainer) (*C.PF_Container_t, e
 	case *e2sm_kpm_ies.PfContainer_OCuCp:
 		pr = C.PF_Container_PR_oCU_CP
 
-		im, err := newOCUCPPFContainer(choice.OCuCp)
+		im, err := newOCuCpPfContainer(choice.OCuCp)
 		if err != nil {
 			return nil, err
 		}
@@ -57,6 +57,20 @@ func newPfContainer(pfContainer *e2sm_kpm_ies.PfContainer) (*C.PF_Container_t, e
 	return &pfContainerC, nil
 }
 
-//func decodeOCUCPPFContainer(gnbIDcC *C.GNB_CU_CP_Name_t) (*e2sm_kpm_ies.GnbIdChoice, error) {
-//	return nil, fmt.Errorf("decodeGnbIDChoice() not yet implemented")
-//}
+func decodePfContainer(pfContainerC *C.PF_Container_t) (*e2sm_kpm_ies.PfContainer, error) {
+	pfContainer := new(e2sm_kpm_ies.PfContainer)
+
+	switch pfContainerC.present {
+	case C.PF_Container_PR_oCU_CP:
+		oCuCpPfContainer := decodeOCuCpContainerBytes(pfContainerC.choice)
+
+		pfContainer.PfContainer = &e2sm_kpm_ies.PfContainer_OCuCp{
+			OCuCp: oCuCpPfContainer,
+		}
+
+	default:
+		return nil, fmt.Errorf("decodePfContainer() %v not yet implemented", pfContainerC.present)
+	}
+
+	return pfContainer, nil
+}


### PR DESCRIPTION
After we finished call, it raised another error during execution of test scenario. Here is it:
```
Bit string {buf:0x4a05730 size:3 bits_unused:2 _asn_ctx:{phase:0 step:0 context:0 ptr:<nil> left:0}}
--- FAIL: Test_newBitString (0.00s)
    BIT_STRING_test.go:20: assertion failed: error is not nil: operation timed out
Bit string {buf:0xc0040b0 size:4 bits_unused:4 _asn_ctx:{phase:0 step:0 context:0 ptr:<nil> left:0}}
--- FAIL: Test_decodeBitString (0.00s)
    BIT_STRING_test.go:61: assertion failed: error is not nil: operation timed out
Bit string {buf:0xc404090 size:3 bits_unused:2 _asn_ctx:{phase:0 step:0 context:0 ptr:<nil> left:0}}
Bit string {buf:0xc4040a0 size:3 bits_unused:2 _asn_ctx:{phase:0 step:0 context:0 ptr:<nil> left:0}}
Bit string {buf:0x4a05750 size:4 bits_unused:4 _asn_ctx:{phase:0 step:0 context:0 ptr:<nil> left:0}}
gNB ID &{0x4a05750 4 4 {0 0 0 <nil> 0}} 8 4 249
FAIL
FAIL	github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/kpmctypes	0.355s
FAIL
```
Try to verify it on your machine.