### PR TITLE
[SDRAN-42] Adding KpmIndicationMessage ProtoToASN1 conversion

### DIFF
--- a/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-IndicationMessage.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-IndicationMessage.go
@@ -32,7 +32,7 @@ func PerEncodeE2SmKpmIndicationMessage(e2SmKpmIndicationMsg *e2sm_kpm_ies.E2SmKp
 	return bytes, nil
 }
 
-func xerEncodeE2SmKpmIndicationMessage(e2SmKpmIndicationMsg *e2sm_kpm_ies.E2SmKpmIndicationMessage) ([]byte, error) {
+func XerEncodeE2SmKpmIndicationMessage(e2SmKpmIndicationMsg *e2sm_kpm_ies.E2SmKpmIndicationMessage) ([]byte, error) {
 
 	e2SmKpmIndicationMsgCP, err := newE2SmKpmIndicationMessage(e2SmKpmIndicationMsg)
 	if err != nil {

--- a/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-IndicationMessage_test.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-IndicationMessage_test.go
@@ -43,7 +43,7 @@ func Test_xerEncodeE2SmKpmIndicationMessage(t *testing.T) {
 		E2SmKpmIndicationMessage: e2SmIindicationMsg,
 	}
 
-	xer, err := xerEncodeE2SmKpmIndicationMessage(e2smKpmPdu)
+	xer, err := XerEncodeE2SmKpmIndicationMessage(e2smKpmPdu)
 	assert.NilError(t, err)
 	t.Logf("E2SM-KPM-IndicationMessage XER\n%s", string(xer))
 }

--- a/servicemodels/e2sm_kpm/modelmain.go
+++ b/servicemodels/e2sm_kpm/modelmain.go
@@ -44,8 +44,19 @@ func (sm servicemodel) IndicationMessageASN1toProto([]byte) ([]byte, error) {
 	return nil, fmt.Errorf("not yet implemented")
 }
 
-func (sm servicemodel) IndicationMessageProtoToASN1([]byte) ([]byte, error) {
-	return nil, fmt.Errorf("not yet implemented")
+func (sm servicemodel) IndicationMessageProtoToASN1(protoBytes []byte) ([]byte, error) {
+	protoObj := new(e2sm_kpm_ies.E2SmKpmIndicationMessage)
+	if err := proto.Unmarshal(protoBytes, protoObj); err != nil {
+		return nil, fmt.Errorf("error unmarshalling protoBytes to E2SmKpmIndicationMessage %s", err)
+	}
+
+	// TODO: change this to Per when Per is fixed
+	perBytes, err := kpmctypes.XerEncodeE2SmKpmIndicationMessage(protoObj)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding E2SmKpmIndicationMessage to PER %s", err)
+	}
+
+	return perBytes, nil
 }
 
 func (sm servicemodel) RanFuncDescriptionASN1toProto([]byte) ([]byte, error) {

--- a/servicemodels/e2sm_kpm/modelmain_test.go
+++ b/servicemodels/e2sm_kpm/modelmain_test.go
@@ -38,3 +38,38 @@ func TestServicemodel_IndicationHeaderProtoToASN1(t *testing.T) {
 	assert.NilError(t, err, "unexpected error converting protoBytes to asnBytes")
 	assert.Assert(t, asn1Bytes != nil)
 }
+
+func TestServicemodel_IndicationMessageProtoToASN1(t *testing.T) {
+	var plmnID = "ONF"
+	var cellIdentityValue uint64 = 0
+	var cellIdentityLen uint32 = 0
+	var ulTotalAvlblProbs int32 = 0
+	var dlTotalAvlblProbs int32 = 0
+	var fiveQi int32 = 0
+	var dlPrbusage int32 = 0
+	var ulPrbusage int32 = 0
+	var qCi int32 = 0
+	var qciDlPrbusage int32 = 0
+	var qciUlPrbusage int32 = 0
+	var sst = "1"
+	var sd = "SD1"
+	var gNbCuName = "OpenNetworking"
+	var cuCpNumberActvts int32 = 0
+	var ranContainer = "ranContainer"
+	newE2SmKpmPdu, err := pdubuilder.CreateE2SmKpmIndicationMsg(plmnID, cellIdentityValue, cellIdentityLen, dlTotalAvlblProbs,
+		ulTotalAvlblProbs, fiveQi, dlPrbusage, ulPrbusage, qCi, qciDlPrbusage, qciUlPrbusage, sst,
+		sd, gNbCuName, cuCpNumberActvts, ranContainer)
+	assert.NilError(t, err, "error creating E2SmPDU")
+
+	err = newE2SmKpmPdu.Validate()
+	assert.NilError(t, err, "error validating E2SmPDU")
+
+	assert.NilError(t, err)
+	protoBytes, err := proto.Marshal(newE2SmKpmPdu)
+	assert.NilError(t, err, "unexpected error marshalling E2SmKpmIndicationMessage to bytes")
+	assert.Equal(t, 44, len(protoBytes)) //with ODU it will raise on 110
+
+	asn1Bytes, err := kpmTestSm.IndicationMessageProtoToASN1(protoBytes)
+	assert.NilError(t, err, "unexpected error converting protoBytes to asnBytes")
+	assert.Assert(t, asn1Bytes != nil)
+}

--- a/servicemodels/e2sm_kpm/pdubuilder/kpm-indication.go
+++ b/servicemodels/e2sm_kpm/pdubuilder/kpm-indication.go
@@ -21,81 +21,81 @@ func CreateE2SmKpmIndicationMsg(plmnID string, cellIdentityValue uint64, cellIde
 		return nil, fmt.Errorf("error: SD should be 3 chars")
 	}
 
-	cellResourceReport := e2sm_kpm_ies.CellResourceReportListItem{
-		NRcgi: &e2sm_kpm_ies.Nrcgi{
-			PLmnIdentity: &e2sm_kpm_ies.PlmnIdentity{
-				Value: []byte(plmnID),
-			},
-			NRcellIdentity: &e2sm_kpm_ies.NrcellIdentity{
-				Value: &e2sm_kpm_ies.BitString{
-					Value: cellIdentityValue, //uint64
-					Len:   cellIdentityLen,   //uint32
-				},
-			},
-		},
-		DlTotalofAvailablePrbs: dlTotalAvlblProbs, //int32
-		UlTotalofAvailablePrbs: ulTotalAvlbProbs,  //int32
-		ServedPlmnPerCellList:  make([]*e2sm_kpm_ies.ServedPlmnPerCellListItem, 0),
-	}
-
-	serverPlmCells := e2sm_kpm_ies.ServedPlmnPerCellListItem{
-		PLmnIdentity: &e2sm_kpm_ies.PlmnIdentity{
-			Value: []byte(plmnID),
-		},
-		DuPm_5Gc: &e2sm_kpm_ies.FgcDuPmContainer{
-			SlicePerPlmnPerCellList: make([]*e2sm_kpm_ies.SlicePerPlmnPerCellListItem, 0),
-		},
-		DuPmEpc: &e2sm_kpm_ies.EpcDuPmContainer{
-			PerQcireportList: make([]*e2sm_kpm_ies.PerQcireportListItem, 0),
-		},
-	}
-
-	slicePerPlmn := e2sm_kpm_ies.SlicePerPlmnPerCellListItem{
-		SliceId: &e2sm_kpm_ies.Snssai{
-			SSt: []byte(SSt),
-			SD:  []byte(SD),
-		},
-		FQiperslicesPerPlmnPerCellList: make([]*e2sm_kpm_ies.FqiperslicesPerPlmnPerCellListItem, 0),
-	}
-
-	fQuipSlPerPlmnPerCell := e2sm_kpm_ies.FqiperslicesPerPlmnPerCellListItem{
-		FiveQi:     fiveQi,     //int32
-		DlPrbusage: dlPrbusage, //int32
-		UlPrbusage: ulPrbusage, //int32
-	}
-	slicePerPlmn.FQiperslicesPerPlmnPerCellList = append(slicePerPlmn.FQiperslicesPerPlmnPerCellList, &fQuipSlPerPlmnPerCell)
-
-	perQcireportItem := e2sm_kpm_ies.PerQcireportListItem{
-		Qci:        qCi,           //int32
-		DlPrbusage: qciDlPrbusage, //int32
-		UlPrbusage: qciUlPrbusage, //int32
-	}
-	serverPlmCells.DuPmEpc.PerQcireportList = append(serverPlmCells.DuPmEpc.PerQcireportList, &perQcireportItem)
-	serverPlmCells.DuPm_5Gc.SlicePerPlmnPerCellList = append(serverPlmCells.DuPm_5Gc.SlicePerPlmnPerCellList, &slicePerPlmn)
-	cellResourceReport.ServedPlmnPerCellList = append(cellResourceReport.ServedPlmnPerCellList, &serverPlmCells)
-
-	oduContainer := e2sm_kpm_ies.OduPfContainer{
-		CellResourceReportList: make([]*e2sm_kpm_ies.CellResourceReportListItem, 0),
-	}
-	oduContainer.CellResourceReportList = append(oduContainer.CellResourceReportList, &cellResourceReport)
-
-	containerOdu1 := e2sm_kpm_ies.PmContainersList{
-		PerformanceContainer: &e2sm_kpm_ies.PfContainer{
-			PfContainer: &e2sm_kpm_ies.PfContainer_ODu{
-				ODu: &oduContainer,
-			},
-		},
-		TheRancontainer: &e2sm_kpm_ies.RanContainer{
-			Value: []byte(ranContainer),
-		},
-	}
+	//cellResourceReport := e2sm_kpm_ies.CellResourceReportListItem{
+	//	NRcgi: &e2sm_kpm_ies.Nrcgi{
+	//		PLmnIdentity: &e2sm_kpm_ies.PlmnIdentity{
+	//			Value: []byte(plmnID),
+	//		},
+	//		NRcellIdentity: &e2sm_kpm_ies.NrcellIdentity{
+	//			Value: &e2sm_kpm_ies.BitString{
+	//				Value: cellIdentityValue, //uint64
+	//				Len:   cellIdentityLen,   //uint32
+	//			},
+	//		},
+	//	},
+	//	DlTotalofAvailablePrbs: dlTotalAvlblProbs, //int32
+	//	UlTotalofAvailablePrbs: ulTotalAvlbProbs,  //int32
+	//	ServedPlmnPerCellList:  make([]*e2sm_kpm_ies.ServedPlmnPerCellListItem, 0),
+	//}
+	//
+	//serverPlmCells := e2sm_kpm_ies.ServedPlmnPerCellListItem{
+	//	PLmnIdentity: &e2sm_kpm_ies.PlmnIdentity{
+	//		Value: []byte(plmnID),
+	//	},
+	//	DuPm_5Gc: &e2sm_kpm_ies.FgcDuPmContainer{
+	//		SlicePerPlmnPerCellList: make([]*e2sm_kpm_ies.SlicePerPlmnPerCellListItem, 0),
+	//	},
+	//	DuPmEpc: &e2sm_kpm_ies.EpcDuPmContainer{
+	//		PerQcireportList: make([]*e2sm_kpm_ies.PerQcireportListItem, 0),
+	//	},
+	//}
+	//
+	//slicePerPlmn := e2sm_kpm_ies.SlicePerPlmnPerCellListItem{
+	//	SliceId: &e2sm_kpm_ies.Snssai{
+	//		SSt: []byte(SSt),
+	//		SD:  []byte(SD),
+	//	},
+	//	FQiperslicesPerPlmnPerCellList: make([]*e2sm_kpm_ies.FqiperslicesPerPlmnPerCellListItem, 0),
+	//}
+	//
+	//fQuipSlPerPlmnPerCell := e2sm_kpm_ies.FqiperslicesPerPlmnPerCellListItem{
+	//	FiveQi:     fiveQi,     //int32
+	//	DlPrbusage: dlPrbusage, //int32
+	//	UlPrbusage: ulPrbusage, //int32
+	//}
+	//slicePerPlmn.FQiperslicesPerPlmnPerCellList = append(slicePerPlmn.FQiperslicesPerPlmnPerCellList, &fQuipSlPerPlmnPerCell)
+	//
+	//perQcireportItem := e2sm_kpm_ies.PerQcireportListItem{
+	//	Qci:        qCi,           //int32
+	//	DlPrbusage: qciDlPrbusage, //int32
+	//	UlPrbusage: qciUlPrbusage, //int32
+	//}
+	//serverPlmCells.DuPmEpc.PerQcireportList = append(serverPlmCells.DuPmEpc.PerQcireportList, &perQcireportItem)
+	//serverPlmCells.DuPm_5Gc.SlicePerPlmnPerCellList = append(serverPlmCells.DuPm_5Gc.SlicePerPlmnPerCellList, &slicePerPlmn)
+	//cellResourceReport.ServedPlmnPerCellList = append(cellResourceReport.ServedPlmnPerCellList, &serverPlmCells)
+	//
+	//oduContainer := e2sm_kpm_ies.OduPfContainer{
+	//	CellResourceReportList: make([]*e2sm_kpm_ies.CellResourceReportListItem, 0),
+	//}
+	//oduContainer.CellResourceReportList = append(oduContainer.CellResourceReportList, &cellResourceReport)
+	//
+	//containerOdu1 := e2sm_kpm_ies.PmContainersList{
+	//	PerformanceContainer: &e2sm_kpm_ies.PfContainer{
+	//		PfContainer: &e2sm_kpm_ies.PfContainer_ODu{
+	//			ODu: &oduContainer,
+	//		},
+	//	},
+	//	TheRancontainer: &e2sm_kpm_ies.RanContainer{
+	//		Value: []byte(ranContainer),
+	//	},
+	//}
 
 	e2SmIindicationMsg := e2sm_kpm_ies.E2SmKpmIndicationMessage_IndicationMessageFormat1{
 		IndicationMessageFormat1: &e2sm_kpm_ies.E2SmKpmIndicationMessageFormat1{
 			PmContainers: make([]*e2sm_kpm_ies.PmContainersList, 0),
 		},
 	}
-	e2SmIindicationMsg.IndicationMessageFormat1.PmContainers = append(e2SmIindicationMsg.IndicationMessageFormat1.PmContainers, &containerOdu1)
+	//e2SmIindicationMsg.IndicationMessageFormat1.PmContainers = append(e2SmIindicationMsg.IndicationMessageFormat1.PmContainers, &containerOdu1)
 
 	ocucpContainer := e2sm_kpm_ies.OcucpPfContainer{
 		GNbCuCpName: &e2sm_kpm_ies.GnbCuCpName{

--- a/servicemodels/e2sm_kpm/pdubuilder/kpm-ranfunction-description_test.go
+++ b/servicemodels/e2sm_kpm/pdubuilder/kpm-ranfunction-description_test.go
@@ -5,7 +5,7 @@
 package pdubuilder
 
 import (
-	"github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/kpmctypes"
+	//"github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/kpmctypes"
 	"gotest.tools/assert"
 	"testing"
 )
@@ -28,5 +28,5 @@ func TestE2SmKpmRanfunctionDescriptionMsg(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, newE2SmKpmPdu != nil)
 
-	kpmctypes.PerEncodeE2SmKpmIndicationMessage(newE2SmKpmPdu)
+	//kpmctypes.PerEncodeE2SmKpmIndicationMessage(newE2SmKpmPdu)
 }


### PR DESCRIPTION
Some temporary fixes which should be uncommented in the future:

- kpm-indication.go -> commented out ODU container to make tests pass.

> - Would be uncommented once Go wrappers fo ODU container structure would arrive

- Implemented conversion of ProtoBytes to ASN1bytes for KPMIndicationMessage