### PR TITLE
[SDRAN-267] E2SM-KPM-ActionDefinition Go code

### DIFF
--- a/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-ActionDefinition.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-ActionDefinition.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package kpmctypes
+
+//#cgo CFLAGS: -I. -D_DEFAULT_SOURCE -DASN_DISABLE_OER_SUPPORT
+//#cgo LDFLAGS: -lm
+//#include <stdio.h>
+//#include <stdlib.h>
+//#include <assert.h>
+//#include "E2SM-KPM-ActionDefinition.h"
+import "C"
+import (
+	"fmt"
+	e2sm_kpm_ies "github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/v1beta1/e2sm-kpm-ies"
+	"unsafe"
+)
+
+func XerEncodeE2SmKpmActionDefinition(actionDefinition *e2sm_kpm_ies.E2SmKpmActionDefinition) ([]byte, error) {
+
+	actionDefinitionCP := newE2SmKpmActionDefinition(actionDefinition)
+
+	bytes, err := encodeXer(&C.asn_DEF_E2SM_KPM_ActionDefinition, unsafe.Pointer(actionDefinitionCP))
+	if err != nil {
+		return nil, fmt.Errorf("xerEncodeE2SmKpmActionDefinition() %s", err.Error())
+	}
+	return bytes, nil
+}
+
+func PerEncodeE2SmKpmActionDefinition(actionDefinition *e2sm_kpm_ies.E2SmKpmActionDefinition) ([]byte, error) {
+	actionDefinitionCP := newE2SmKpmActionDefinition(actionDefinition)
+
+	bytes, err := encodePerBuffer(&C.asn_DEF_E2SM_KPM_ActionDefinition, unsafe.Pointer(actionDefinitionCP))
+	if err != nil {
+		return nil, fmt.Errorf("PerEncodeE2SmKpmActionDefinition() %s", err.Error())
+	}
+	return bytes, nil
+}
+
+func XerDecodeE2SmKpmActionDefinition(bytes []byte) (*e2sm_kpm_ies.E2SmKpmActionDefinition, error) {
+	unsafePtr, err := decodeXer(bytes, &C.asn_DEF_E2SM_KPM_ActionDefinition)
+	if err != nil {
+		return nil, err
+	}
+	if unsafePtr == nil {
+		return nil, fmt.Errorf("pointer decoded from XER is nil")
+	}
+	return decodeE2SmKpmActionDefinition((*C.E2SM_KPM_ActionDefinition_t)(unsafePtr)), nil
+}
+
+func PerDecodeE2SmKpmActionDefinition(bytes []byte) (*e2sm_kpm_ies.E2SmKpmActionDefinition, error) {
+	unsafePtr, err := decodePer(bytes, len(bytes), &C.asn_DEF_E2SM_KPM_ActionDefinition)
+	if err != nil {
+		return nil, err
+	}
+	if unsafePtr == nil {
+		return nil, fmt.Errorf("pointer decoded from PER is nil")
+	}
+	return decodeE2SmKpmActionDefinition((*C.E2SM_KPM_ActionDefinition_t)(unsafePtr)), nil
+}
+
+func newE2SmKpmActionDefinition(actionDefinition *e2sm_kpm_ies.E2SmKpmActionDefinition) *C.E2SM_KPM_ActionDefinition_t {
+
+	ricStyleTypeC := newRicStyleType(actionDefinition.GetRicStyleType())
+
+	actionDefinitionC := C.E2SM_KPM_ActionDefinition_t{
+		ric_Style_Type: *ricStyleTypeC,
+	}
+
+	return &actionDefinitionC
+}
+
+func decodeE2SmKpmActionDefinition(actionDefinitionC *C.E2SM_KPM_ActionDefinition_t) *e2sm_kpm_ies.E2SmKpmActionDefinition {
+
+	ricStyleType := decodeRicStyleType(&actionDefinitionC.ric_Style_Type)
+
+	return &e2sm_kpm_ies.E2SmKpmActionDefinition{
+		RicStyleType: ricStyleType,
+	}
+}

--- a/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-ActionDefinition_test.go
+++ b/servicemodels/e2sm_kpm/kpmctypes/E2SM-KPM-ActionDefinition_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package kpmctypes
+
+import (
+	"github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/pdubuilder"
+	"gotest.tools/assert"
+	"testing"
+)
+
+func Test_xerEncodeE2SmKpmActionDefinition(t *testing.T) {
+
+	e2SmKpmActionDefinition, err := pdubuilder.CreateE2SmKpmActionDefinition(12)
+	assert.NilError(t, err)
+
+	xer, err := XerEncodeE2SmKpmActionDefinition(e2SmKpmActionDefinition)
+	assert.NilError(t, err)
+	assert.Equal(t, 97, len(xer))
+	t.Logf("E2SM-KPM-ActionDefinition XER\n%s", string(xer))
+}
+
+func Test_xerDecodeE2SmKpmActionDefinition(t *testing.T) {
+
+	e2SmKpmActionDefinition, err := pdubuilder.CreateE2SmKpmActionDefinition(12)
+	assert.NilError(t, err)
+
+	xer, err := XerEncodeE2SmKpmActionDefinition(e2SmKpmActionDefinition)
+	assert.NilError(t, err)
+	assert.Equal(t, 97, len(xer))
+	t.Logf("E2SM-KPM-ActionDefinition XER\n%s", string(xer))
+
+	result, err := XerDecodeE2SmKpmActionDefinition(xer)
+	assert.NilError(t, err)
+	assert.Equal(t, e2SmKpmActionDefinition.GetRicStyleType().GetValue(), result.GetRicStyleType().GetValue(), "Encoded and decoded values are not the same")
+}
+
+func Test_perEncodeE2SmKpmActionDefinition(t *testing.T) {
+
+	e2SmKpmActionDefinition, err := pdubuilder.CreateE2SmKpmActionDefinition(12)
+	assert.NilError(t, err)
+
+	per, err := PerEncodeE2SmKpmActionDefinition(e2SmKpmActionDefinition)
+	assert.NilError(t, err)
+	assert.Equal(t, 3, len(per))
+	t.Logf("E2SM-KPM-ActionDefinition PER\n%s", string(per))
+}
+
+func Test_perDecodeE2SmKpmActionDefinition(t *testing.T) {
+
+	e2SmKpmActionDefinition, err := pdubuilder.CreateE2SmKpmActionDefinition(12)
+	assert.NilError(t, err)
+
+	per, err := PerEncodeE2SmKpmActionDefinition(e2SmKpmActionDefinition)
+	assert.NilError(t, err)
+	assert.Equal(t, 3, len(per))
+	t.Logf("E2SM-KPM-ActionDefinition PER\n%s", string(per))
+
+	result, err := PerDecodeE2SmKpmActionDefinition(per)
+	assert.NilError(t, err)
+	assert.Equal(t, e2SmKpmActionDefinition.GetRicStyleType().GetValue(), result.GetRicStyleType().GetValue(), "Encoded and decoded values are not the same")
+}

--- a/servicemodels/e2sm_kpm/pdubuilder/kpm-action-definition.go
+++ b/servicemodels/e2sm_kpm/pdubuilder/kpm-action-definition.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+package pdubuilder
+
+import (
+	"fmt"
+	e2sm_kpm_ies "github.com/onosproject/onos-e2-sm/servicemodels/e2sm_kpm/v1beta1/e2sm-kpm-ies"
+)
+
+func CreateE2SmKpmActionDefinition(actionDef int32) (*e2sm_kpm_ies.E2SmKpmActionDefinition, error) {
+
+	e2SmKpmPdu := e2sm_kpm_ies.E2SmKpmActionDefinition{
+		RicStyleType: &e2sm_kpm_ies.RicStyleType{
+			Value: actionDef,
+		},
+	}
+
+	if err := e2SmKpmPdu.Validate(); err != nil {
+		return nil, fmt.Errorf("error validating E2SmKpmPDU %s", err.Error())
+	}
+	return &e2SmKpmPdu, nil
+}

--- a/servicemodels/e2sm_kpm/pdubuilder/kpm-action-definition_test.go
+++ b/servicemodels/e2sm_kpm/pdubuilder/kpm-action-definition_test.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package pdubuilder
+
+import (
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestE2SmKpmActionDefinition(t *testing.T) {
+	var ActionDef int32 = 12
+
+	newE2SmKpmPdu, err := CreateE2SmKpmActionDefinition(ActionDef)
+	assert.NilError(t, err)
+	assert.Assert(t, newE2SmKpmPdu != nil)
+}


### PR DESCRIPTION
ASN1bytes <-> ProtoBytes encoders (in `modelmain.go`) will come in a separate PR