### PR TITLE
[SDRAN-401] Fixing some minor bugs in PG-CGo

### DIFF
--- a/protoc-gen-cgo/INTEGER.tpl
+++ b/protoc-gen-cgo/INTEGER.tpl
@@ -130,6 +130,13 @@ func decodeInteger(intC *C.INTEGER_t) (int64, error) {
 	return ni.Int64(), nil
 }
 
+// Input value should always be 8 bytes. If you have more than 8 bytes,
+// please split it on slices of 8 bytes and run this function on each slice
+func decodeIntegerBytes(array [8]byte) (int64, error) {
+	intC := (*C.INTEGER_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:]))))
+	return decodeInteger(intC), nil
+}
+
 func freeInteger(intC *C.INTEGER_t) {
 	freeAsnCodecsPrim(intC)
 }

--- a/protoc-gen-cgo/enum.tpl
+++ b/protoc-gen-cgo/enum.tpl
@@ -46,10 +46,10 @@ func perEncode{{.MessageName}}({{lowCaseFirstLetter .MessageName}} {{.ProtoFileN
 func xerDecode{{.MessageName}}(bytes []byte) ({{.ProtoFileName}}.{{.MessageName}}, error) {
     unsafePtr, err := decodeXer(bytes, &C.asn_DEF_{{dashToUnderscore .CstructName}})
     if err != nil {
-        return nil, err
+        return 0, err
     }
     if unsafePtr == nil {
-        return nil, fmt.Errorf("pointer decoded from XER is nil")
+        return 0, fmt.Errorf("pointer decoded from XER is nil")
     }
     return decode{{.MessageName}}((*C.{{dashToUnderscore .CstructName}}_t)(unsafePtr)) //ToDo - change name of C-struct
 }
@@ -57,10 +57,10 @@ func xerDecode{{.MessageName}}(bytes []byte) ({{.ProtoFileName}}.{{.MessageName}
 func perDecode{{.MessageName}}(bytes []byte) ({{.ProtoFileName}}.{{.MessageName}}, error) {
     unsafePtr, err := decodePer(bytes, len(bytes), &C.asn_DEF_{{dashToUnderscore .CstructName}})
     if err != nil {
-        return nil, err
+        return 0, err
     }
     if unsafePtr == nil {
-       return nil, fmt.Errorf("pointer decoded from PER is nil")
+       return 0, fmt.Errorf("pointer decoded from PER is nil")
     }
     return decode{{.MessageName}}((*C.{{dashToUnderscore .CstructName}}_t)(unsafePtr))
 }
@@ -69,9 +69,9 @@ func new{{.MessageName}}({{lowCaseFirstLetter .MessageName}} {{.ProtoFileName}}.
     var ret C.{{dashToUnderscore .CstructName}}_t
     switch {{lowCaseFirstLetter .MessageName}} { {{with .FieldList}}{{ range . }}
             case {{.ProtoFileName}}.{{.MessageName}}_{{.FieldName}}:
-                ret = C.{{.CstructLeafName}} {{ end }}{{end}}
+                ret = C.{{.CstructLeafName}} //ToDo - double-check correctness of the name {{ end }}{{end}}
     default:
-        return 0, fmt.Errorf("unexpected {{underscoreToDash .CstructName}} %v", {{lowCaseFirstLetter .MessageName}})
+        return 0, fmt.Errorf("unexpected {{underscoreToDash .MessageName}} %v", {{lowCaseFirstLetter .MessageName}})
     }
 
 
@@ -84,4 +84,10 @@ func decode{{.MessageName}}({{lowCaseFirstLetter .MessageName}}C *C.{{dashToUnde
     {{lowCaseFirstLetter .MessageName}} := {{.ProtoFileName}}.{{.MessageName}}(int32(*{{lowCaseFirstLetter .MessageName}}C))
 
     return {{lowCaseFirstLetter .MessageName}}, nil
+}
+
+func decode{{.MessageName}}Bytes(array [8]byte) (*{{.ProtoFileName}}.{{.MessageName}}, error) { //ToDo - Check addressing correct structure in Protobuf
+    {{lowCaseFirstLetter .MessageName}}C := (*C.{{dashToUnderscore .MessageName}}_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:8]))))
+
+    return decode{{.MessageName}}({{lowCaseFirstLetter .MessageName}}C)
 }


### PR DESCRIPTION
What was improved:
- fixed package name issue (in imports)
- improved handling of single-leaf OPTIONAL types (like RicStyleType and others) comparing to top-level single-leaf messages (i.e. ActionDefinition)
- fixed an issue with C-struct leaf naming
- introducing PrintableString encoding and decoding (linked to string types in proto)
- improved comments (ToDo ones)
- improved linking to functions in error messages
- decodeBytes function embedded in every message (in case of need), redundant code was removed
- pointers to switch-case statement are back
- some typos

What is missing:
- handling nested messages (started? but not implemented)
- linting of variable names and functions
- better pointers handling
- embedding some elementary types as OctetString and any others
- put as much logic (and string processing) out of the templates as possible