### PR TITLE
e2sm_rc_pre: Remove hard-coded values

### DIFF
--- a/servicemodels/e2sm_rc_pre/modelmain_test.go
+++ b/servicemodels/e2sm_rc_pre/modelmain_test.go
@@ -179,7 +179,9 @@ func TestServicemodel_ActionDefinitionProtoToASN1(t *testing.T) {
 
 func TestServicemodel_ControlHeaderProtoToASN1(t *testing.T) {
 
-	newE2SmRcPrePdu, err := pdubuilder.CreateE2SmRcPreControlHeader()
+	var controlMessagePriority int32 = 1
+
+	newE2SmRcPrePdu, err := pdubuilder.CreateE2SmRcPreControlHeader(controlMessagePriority)
 	assert.NilError(t, err, "error creating E2SmPDU")
 
 	err = newE2SmRcPrePdu.Validate()
@@ -213,8 +215,9 @@ func TestServicemodel_ControlHeaderASN1toProto(t *testing.T) {
 func TestServicemodel_ControlMessageProtoToASN1(t *testing.T) {
 	var ranParameterName = "PCI"
 	var ranParameterValue int32 = 20
+	var ranParameterID int32 = 1
 
-	newE2SmRcPrePdu, err := pdubuilder.CreateE2SmRcPreControlMessage(ranParameterName, ranParameterValue)
+	newE2SmRcPrePdu, err := pdubuilder.CreateE2SmRcPreControlMessage(ranParameterID, ranParameterName, ranParameterValue)
 	assert.NilError(t, err, "error creating E2SmPDU")
 
 	err = newE2SmRcPrePdu.Validate()

--- a/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-header.go
+++ b/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-header.go
@@ -8,12 +8,12 @@ import (
 	e2sm_rc_pre_ies "github.com/onosproject/onos-e2-sm/servicemodels/e2sm_rc_pre/v1/e2sm-rc-pre-ies"
 )
 
-func CreateE2SmRcPreControlHeader() (*e2sm_rc_pre_ies.E2SmRcPreControlHeader, error) {
+func CreateE2SmRcPreControlHeader(controlMessagePriority int32) (*e2sm_rc_pre_ies.E2SmRcPreControlHeader, error) {
 
 	e2smRcPreFormat1 := e2sm_rc_pre_ies.E2SmRcPreControlHeaderFormat1{
 		RcCommand: e2sm_rc_pre_ies.RcPreCommand_RC_PRE_COMMAND_SET_PARAMETERS,
 		RicControlMessagePriority: &e2sm_rc_pre_ies.RicControlMessagePriority{
-			Value: 1,
+			Value: controlMessagePriority,
 		},
 	}
 	e2smRcPrePdu := e2sm_rc_pre_ies.E2SmRcPreControlHeader{

--- a/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-header_test.go
+++ b/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-header_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 func TestE2SmRcPreControlHeader(t *testing.T) {
+	var controlMessagePriority int32 = 1
 
-	newE2SmRcPrePdu, err := CreateE2SmRcPreControlHeader()
+	newE2SmRcPrePdu, err := CreateE2SmRcPreControlHeader(controlMessagePriority)
 	assert.NilError(t, err)
 	assert.Assert(t, newE2SmRcPrePdu != nil)
 

--- a/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-message.go
+++ b/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-message.go
@@ -8,12 +8,12 @@ import (
 	e2sm_rc_pre_ies "github.com/onosproject/onos-e2-sm/servicemodels/e2sm_rc_pre/v1/e2sm-rc-pre-ies"
 )
 
-func CreateE2SmRcPreControlMessage(RANparameterName string, RANparameterValue int32) (*e2sm_rc_pre_ies.E2SmRcPreControlMessage, error) {
+func CreateE2SmRcPreControlMessage(RANparameterID int32, RANparameterName string, RANparameterValue int32) (*e2sm_rc_pre_ies.E2SmRcPreControlMessage, error) {
 
 	e2smRcPreMsgFormat1 := e2sm_rc_pre_ies.E2SmRcPreControlMessageFormat1{
 		ParameterType: &e2sm_rc_pre_ies.RanparameterDefItem{
 			RanParameterId: &e2sm_rc_pre_ies.RanparameterId{
-				Value: 20,
+				Value: RANparameterID,
 			},
 			RanParameterName: &e2sm_rc_pre_ies.RanparameterName{
 				Value: RANparameterName,

--- a/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-message_test.go
+++ b/servicemodels/e2sm_rc_pre/pdubuilder/rc-pre-control-message_test.go
@@ -13,8 +13,9 @@ import (
 func TestE2SmRcPreControlMsg(t *testing.T) {
 	var ranParameterName = "PCI"
 	var ranParameterValue int32 = 10
+	var ranParameterID int32 = 1
 
-	newE2SmRcPrePdu, err := CreateE2SmRcPreControlMessage(ranParameterName, ranParameterValue)
+	newE2SmRcPrePdu, err := CreateE2SmRcPreControlMessage(ranParameterID, ranParameterName, ranParameterValue)
 	assert.NilError(t, err)
 	assert.Assert(t, newE2SmRcPrePdu != nil)
 

--- a/servicemodels/e2sm_rc_pre/rcprectypes/E2SM-RC-PRE-ControlHeader_test.go
+++ b/servicemodels/e2sm_rc_pre/rcprectypes/E2SM-RC-PRE-ControlHeader_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func Test_XerEncodeE2SmRcPreControlHeader(t *testing.T) {
-	e2SmRcPreControlHeader, err := pdubuilder.CreateE2SmRcPreControlHeader()
+	var controlMessagePriority int32 = 1
+	e2SmRcPreControlHeader, err := pdubuilder.CreateE2SmRcPreControlHeader(controlMessagePriority)
 	assert.NilError(t, err)
 
 	xer, err := XerEncodeE2SmRcPreControlHeader(e2SmRcPreControlHeader)
@@ -21,8 +22,9 @@ func Test_XerEncodeE2SmRcPreControlHeader(t *testing.T) {
 }
 
 func Test_XerDecodeE2SmRcPreControlHeader(t *testing.T) {
+	var controlMessagePriority int32 = 1
 
-	e2SmRcPreControlHeader, err := pdubuilder.CreateE2SmRcPreControlHeader()
+	e2SmRcPreControlHeader, err := pdubuilder.CreateE2SmRcPreControlHeader(controlMessagePriority)
 	assert.NilError(t, err)
 
 	xer, err := XerEncodeE2SmRcPreControlHeader(e2SmRcPreControlHeader)

--- a/servicemodels/e2sm_rc_pre/rcprectypes/E2SM-RC-PRE-ControlMessage_test.go
+++ b/servicemodels/e2sm_rc_pre/rcprectypes/E2SM-RC-PRE-ControlMessage_test.go
@@ -13,24 +13,28 @@ import (
 func Test_XerEncodeE2SmRcPreControlMessage(t *testing.T) {
 	var ranParameterName = "PCI"
 	var ranParameterValue int32 = 10
-	e2SmRcPreControlMessage, err := pdubuilder.CreateE2SmRcPreControlMessage(ranParameterName, ranParameterValue)
+	var ranParameterID int32 = 1
+
+	e2SmRcPreControlMessage, err := pdubuilder.CreateE2SmRcPreControlMessage(ranParameterID, ranParameterName, ranParameterValue)
 	assert.NilError(t, err)
 
 	xer, err := XerEncodeE2SmRcPreControlMessage(e2SmRcPreControlMessage)
 	assert.NilError(t, err)
-	assert.Equal(t, 411, len(xer))
+	assert.Equal(t, 410, len(xer))
 	t.Logf("E2SM-RC-PRE-ControlMessage XER\n%s", string(xer))
 }
 
 func Test_XerDecodeE2SmRcPreControlMessage(t *testing.T) {
 	var ranParameterName = "PCI"
 	var ranParameterValue int32 = 10
-	e2SmRcPreControlMessage, err := pdubuilder.CreateE2SmRcPreControlMessage(ranParameterName, ranParameterValue)
+	var ranParameterID int32 = 1
+
+	e2SmRcPreControlMessage, err := pdubuilder.CreateE2SmRcPreControlMessage(ranParameterID, ranParameterName, ranParameterValue)
 	assert.NilError(t, err)
 
 	xer, err := XerEncodeE2SmRcPreControlMessage(e2SmRcPreControlMessage)
 	assert.NilError(t, err)
-	assert.Equal(t, 411, len(xer))
+	assert.Equal(t, 410, len(xer))
 	t.Logf("E2SM-RC-PRE-ControlMessage XER\n%s", string(xer))
 
 	result, err := XerDecodeE2SmRcPreControlMessage(xer)


### PR DESCRIPTION
Removed hard-coded values  RANParameterID and ControlMessagePriority.

RANParameterValue is still hard-coded to 20 (decode issues).