### PR TITLE
PGCGo - minor fix to templates for code generation

### DIFF
--- a/protoc-gen-cgo/OCTET_STRING.tpl
+++ b/protoc-gen-cgo/OCTET_STRING.tpl
@@ -37,3 +37,8 @@ func decodeOctetString(octC *C.OCTET_STRING_t) (string, error) {
 //func freeOctetString(octC *C.OCTET_STRING_t) {
 //	C.free(unsafe.Pointer(octC))
 //}
+
+func decodeOctetStrinBytes(array [16]byte) (string, error) {
+	osC := (*C.OCTET_STRING_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:]))))
+	return decodeOctetString(osC)
+}

--- a/protoc-gen-cgo/PrintableString.tpl
+++ b/protoc-gen-cgo/PrintableString.tpl
@@ -34,3 +34,8 @@ func decodePrintableString(octC *C.PrintableString_t) (string, error) {
 
 	return bytes, nil
 }
+
+func decodePrintableStringBytes(array [16]byte) (string, error) {
+	psC := (*C.PrintableString_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:]))))
+	return decodePrintableString(psC)
+}

--- a/protoc-gen-cgo/enum.tpl
+++ b/protoc-gen-cgo/enum.tpl
@@ -87,7 +87,7 @@ func decode{{.MessageName}}({{lowCaseFirstLetter .MessageName}}C *C.{{dashToUnde
 }
 
 func decode{{.MessageName}}Bytes(array [8]byte) (*{{.ProtoFileName}}.{{.MessageName}}, error) { //ToDo - Check addressing correct structure in Protobuf
-    {{lowCaseFirstLetter .MessageName}}C := (*C.{{dashToUnderscore .MessageName}}_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:8]))))
+    {{lowCaseFirstLetter .MessageName}}C := (*C.{{dashToUnderscore .MessageName}}_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:]))))
 
     return decode{{.MessageName}}({{lowCaseFirstLetter .MessageName}}C)
 }

--- a/protoc-gen-cgo/message.tpl
+++ b/protoc-gen-cgo/message.tpl
@@ -211,8 +211,8 @@ return decode{{.MessageName}}({{lowCaseFirstLetter .MessageName}}C)
 {{ define "OPTIONAL_DECODE" }}
 {{ $fields := .FieldList.OptionalField }}
 {{ range $fieldIndex, $field := $fields }}{{if checkElementaryType .DataType}}
-{{lowCaseFirstLetter .FieldName}} := {{decodeDataType .DataType}}(*{{lowCaseFirstLetter .MessageName}}C.{{.CstructLeafName}}){{else}}
-{{lowCaseFirstLetter .FieldName}}, err := {{decodeDataType .DataType}}(*{{lowCaseFirstLetter .MessageName}}C.{{.CstructLeafName}})
+{{lowCaseFirstLetter .FieldName}} := {{decodeDataType .DataType}}({{lowCaseFirstLetter .MessageName}}C.{{.CstructLeafName}}){{else}}
+{{lowCaseFirstLetter .FieldName}}, err := {{decodeDataType .DataType}}({{lowCaseFirstLetter .MessageName}}C.{{.CstructLeafName}})
 if err != nil {
 return nil, fmt.Errorf("{{decodeDataType .DataType}}() %s", err.Error())
 }


### PR DESCRIPTION
Some minor fixes to propagate decodeSmthBytes function to OctetString and PrintableString. Also fixing unused dereference in decoding