### PR TITLE
Updating PG-CGo template for BitString

### DIFF
--- a/protoc-gen-cgo/BIT_STRING.tpl
+++ b/protoc-gen-cgo/BIT_STRING.tpl
@@ -19,7 +19,7 @@ import (
 "unsafe"
 )
 
-func xerEncodeBitString(bs *e2sm_kpm_v2.BitString) ([]byte, error) {
+func xerEncodeBitString(bs *{{.ProtoFileName}}.BitString) ([]byte, error) {
 	bsC, err := newBitString(bs)
 	if err != nil {
 		return nil, fmt.Errorf("newBitString() %s", err.Error())
@@ -32,7 +32,7 @@ func xerEncodeBitString(bs *e2sm_kpm_v2.BitString) ([]byte, error) {
 	return bytes, nil
 }
 
-func xerDecodeBitString(bytes []byte) (*e2sm_kpm_v2.BitString, error) {
+func xerDecodeBitString(bytes []byte) (*{{.ProtoFileName}}, error) {
 	unsafePtr, err := decodeXer(bytes, &C.asn_DEF_BIT_STRING)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func xerDecodeBitString(bytes []byte) (*e2sm_kpm_v2.BitString, error) {
 	return decodeBitString((*C.BIT_STRING_t)(unsafePtr))
 }
 
-func perEncodeBitString(bs *e2sm_kpm_v2.BitString) ([]byte, error) {
+func perEncodeBitString(bs *{{.ProtoFileName}}.BitString) ([]byte, error) {
 	bsC, err := newBitString(bs)
 	if err != nil {
 		return nil, fmt.Errorf("newBitString() %s", err.Error())
@@ -57,7 +57,7 @@ func perEncodeBitString(bs *e2sm_kpm_v2.BitString) ([]byte, error) {
 	return bytes, nil
 }
 
-func perDecodeBitString(bytes []byte) (*e2sm_kpm_v2.BitString, error) {
+func perDecodeBitString(bytes []byte) (*{{.ProtoFileName}}.BitString, error) {
 	unsafePtr, err := decodePer(bytes, len(bytes), &C.asn_DEF_BIT_STRING)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func perDecodeBitString(bytes []byte) (*e2sm_kpm_v2.BitString, error) {
 	return decodeBitString((*C.BIT_STRING_t)(unsafePtr))
 }
 
-//func newBitString(bs *e2sm_kpm_v2.BitString) (*C.BIT_STRING_t, error) {
+//func newBitString(bs *{{.ProtoFileName}}.BitString) (*C.BIT_STRING_t, error) {
 //	numBytes := int(math.Ceil(float64(bs.Len) / 8.0))
 //	valAsBytes := make([]byte, 8)
 //	binary.LittleEndian.PutUint64(valAsBytes, bs.Value)
@@ -92,7 +92,7 @@ func perDecodeBitString(bytes []byte) (*e2sm_kpm_v2.BitString, error) {
 // This additional 4 zeroes shift is Octet alignment - bits should be aligned to the left of available bytes.
 // Why 4 bits? 24-20 = 4.
 // For more example, see examples in Test_validBitStringsOne in BIT_STRING_test.go
-func newBitString(bs *e2sm_kpm_v2.BitString) (*C.BIT_STRING_t, error) {
+func newBitString(bs *{{.ProtoFileName}}.BitString) (*C.BIT_STRING_t, error) {
 	//fmt.Printf("Bit String value is %x\nBitString length (size) is %v\n", bs.Value, bs.Len)
 	numBytes := int(math.Ceil(float64(bs.Len) / 8.0))
 	//fmt.Printf("Number of bytes is %v\n", numBytes)
@@ -140,7 +140,7 @@ func newBitStringFromArray(array [48]byte) *C.BIT_STRING_t {
 // decodeBitString - byteString in C has 20 bytes
 // 8 for a 64bit address of a buffer, 8 for the size in bytes of the buffer uint64, 4 for the unused bits
 // The unused bits are at the end of the buffer
-func decodeBitString(bsC *C.BIT_STRING_t) (*e2sm_kpm_v2.BitString, error) {
+func decodeBitString(bsC *C.BIT_STRING_t) (*{{.ProtoFileName}}.BitString, error) {
 	size := uint32(bsC.size)
 	bitsUnused := uint32(bsC.bits_unused)
 	if bitsUnused > 7 {
@@ -163,7 +163,7 @@ func decodeBitString(bsC *C.BIT_STRING_t) (*e2sm_kpm_v2.BitString, error) {
 	//	//goBytes[i] = bytes[i]
 	//	goBytes = append(goBytes, bytes[i])
 	//}
-	bs := &e2sm_kpm_v2.BitString{
+	bs := &{{.ProtoFileName}}.BitString{
 		Value: bytes,
 		Len:   size*8 - bitsUnused,
 	}
@@ -171,7 +171,7 @@ func decodeBitString(bsC *C.BIT_STRING_t) (*e2sm_kpm_v2.BitString, error) {
 	return bs, nil
 }
 
-//func decodeBitStringBytes(array [8]byte) (*e2sm_kpm_v2.BitString, error) {
+//func decodeBitStringBytes(array [8]byte) (*{{.ProtoFileName}}.BitString, error) {
 //	bsC := (*C.BIT_STRING_t)(unsafe.Pointer(uintptr(binary.LittleEndian.Uint64(array[0:8]))))
 //
 //	return decodeBitString(bsC)


### PR DESCRIPTION
Updating PG-CGo template for BitString - now it handles BitString through byte array