### PR TITLE
Fix build for now

### DIFF
--- a/servicemodels/e2sm_kpm_v2_go/go.mod
+++ b/servicemodels/e2sm_kpm_v2_go/go.mod
@@ -5,10 +5,12 @@ go 1.15
 require (
 	github.com/envoyproxy/protoc-gen-validate v0.4.1
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/protobuf v1.5.0 // indirect
 	github.com/onosproject/onos-api/go v0.7.85
 	github.com/onosproject/onos-lib-go v0.7.16
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
+	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	google.golang.org/protobuf v1.26.0
 	gotest.tools v2.2.0+incompatible
 )
-
-//replace github.com/onosproject/onos-lib-go => ../../../onos-lib-go

--- a/servicemodels/e2sm_kpm_v2_go/go.sum
+++ b/servicemodels/e2sm_kpm_v2_go/go.sum
@@ -210,6 +210,8 @@ github.com/onosproject/onos-api/go v0.7.85 h1:qOd0SrLWWawLN+IXdvCbQMYauSQnT95506
 github.com/onosproject/onos-api/go v0.7.85/go.mod h1:dUChRuNCBGrF6sVdaAZl5T2ZeyEC6ybsAdEBu0YwlMw=
 github.com/onosproject/onos-lib-go v0.7.16 h1:bq6UWjhvraqFBxT77hi55ISV89bfmR2NClgT11/UMRE=
 github.com/onosproject/onos-lib-go v0.7.16/go.mod h1:yEu+qDh+z1G6b9clPAjDLQNnBll8TMl8o2sFDBzk/fI=
+github.com/onosproject/onos-lib-go v0.7.17 h1:Zd5S2q0ZXg/QuNNmzz2nZI2VD5kty6bnoJChigUxXCc=
+github.com/onosproject/onos-lib-go v0.7.17/go.mod h1:yEu+qDh+z1G6b9clPAjDLQNnBll8TMl8o2sFDBzk/fI=
 github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/goyang v0.0.0-20200115183954-d0a48929f0ea/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=


### PR DESCRIPTION
This PR fixes build of image of new SM in go for ransim but the goal is to use go modules directly for go based service models instead of building plugins. 