### PR TITLE
Pdubuilder if conditions fix

### DIFF
--- a/servicemodels/e2sm_kpm_v2_go/pdubuilder/kpm-indication-header.go
+++ b/servicemodels/e2sm_kpm_v2_go/pdubuilder/kpm-indication-header.go
@@ -39,7 +39,7 @@ func CreateGlobalKpmnodeIDgNBID(bs *asn1.BitString, plmnID []byte) (*e2sm_kpm_v2
 		return nil, fmt.Errorf("PlmnID should be 3 chars")
 	}
 
-	if bs.GetLen() < 22 && bs.GetLen() > 32 {
+	if bs.GetLen() < 22 || bs.GetLen() > 32 {
 		return nil, fmt.Errorf("expecting GNbID length in range 22 to 32 bits, got %d", bs.GetLen())
 	}
 
@@ -67,7 +67,7 @@ func CreateGlobalKpmnodeIDenGNbID(bsValue []byte, bsLen uint32, plmnID []byte) (
 		return nil, fmt.Errorf("PlmnID should be 3 chars")
 	}
 
-	if bsLen < 22 && bsLen > 32 {
+	if bsLen < 22 || bsLen > 32 {
 		return nil, fmt.Errorf("expecting GNbID length in range 22 to 32 bits, got %d", bsLen)
 	}
 

--- a/servicemodels/e2sm_rsm/pdubuilder/E2SM-RSM-RanFunctionDescription_test.go
+++ b/servicemodels/e2sm_rsm/pdubuilder/E2SM-RSM-RanFunctionDescription_test.go
@@ -31,6 +31,7 @@ func TestCreateE2SmRsmRanFunctionDescription(t *testing.T) {
 	rfd := CreateE2SmRsmRanFunctionDescription("E2SM-RSM",
 		"1.3.6.1.4.1.53148.1.1.2.102", "RAN Slicing Service Model", slicingCapList)
 	assert.Assert(t, rfd != nil)
+	rfd.GetRanFunctionName().SetRanFunctionInstance(2)
 	t.Logf("Created E2SM-RSM-RanFunctionDescription is \n%v", rfd)
 
 	// APER encoding validation

--- a/servicemodels/e2sm_rsm/v1/e2sm-v2-ies/builder.go
+++ b/servicemodels/e2sm_rsm/v1/e2sm-v2-ies/builder.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package e2sm_v2_ies
+
+func (m *RanfunctionName) SetRanFunctionInstance(rfi int32) *RanfunctionName {
+	m.RanFunctionInstance = &rfi
+	return m
+}


### PR DESCRIPTION
A minor fix to if condition in PDUbuilder for KPMv2 with Go APER and adding a builder for E2SMv2 to enable setting RanFunctionInstance of RanFunctionName.